### PR TITLE
45 update or delete existing cats

### DIFF
--- a/feral-cat-tracker-UI/src/app/app-routing.module.ts
+++ b/feral-cat-tracker-UI/src/app/app-routing.module.ts
@@ -8,6 +8,7 @@ import { LogcatComponent } from './logcat/logcat.component';
 import { FindcatComponent } from './findcat/findcat.component';
 import { SearchResultsComponent } from './search-results/search-results.component';
 import { CatProfilePageComponent } from './cat-profile-page/cat-profile-page.component';
+import { UpdateCatProfilePageComponent } from './update-cat-profile-page/update-cat-profile-page.component';
 
 const routes: Routes = [
   {
@@ -46,7 +47,9 @@ const routes: Routes = [
   {
     path: 'catProfile',
     component:CatProfilePageComponent
-  }
+  },
+  { path: 'updateCat',
+  component:UpdateCatProfilePageComponent}
   
   
 

--- a/feral-cat-tracker-UI/src/app/app.module.ts
+++ b/feral-cat-tracker-UI/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { CatCardUiComponent } from './cat-card-ui/cat-card-ui.component';
 import { SearchFormComponent } from './search-form/search-form.component';
 import { SearchResultsComponent } from './search-results/search-results.component';
 import { CatProfilePageComponent } from './cat-profile-page/cat-profile-page.component';
+import { UpdateCatProfilePageComponent } from './update-cat-profile-page/update-cat-profile-page.component';
 
 
 
@@ -39,6 +40,7 @@ import { CatProfilePageComponent } from './cat-profile-page/cat-profile-page.com
     SearchFormComponent,
     SearchResultsComponent,
     CatProfilePageComponent,
+    UpdateCatProfilePageComponent,
 
   ],
   imports: [

--- a/feral-cat-tracker-UI/src/app/cat-card-ui/cat-card-ui.component.css
+++ b/feral-cat-tracker-UI/src/app/cat-card-ui/cat-card-ui.component.css
@@ -2,3 +2,7 @@ img {
     margin: auto;
     padding-top: 5px;
 }
+.card{
+  background-color: #45b6787a;
+  
+}

--- a/feral-cat-tracker-UI/src/app/cat-card-ui/cat-card-ui.component.html
+++ b/feral-cat-tracker-UI/src/app/cat-card-ui/cat-card-ui.component.html
@@ -1,5 +1,5 @@
 <div class="card">
-    <img src="{{cat.fileDownloadUri}}" alt="{{cat.fileName}}" width="250" height="250"
+    <img class="rounded" src="{{cat.fileDownloadUri}}" alt="{{cat.fileName}}" width="250" height="250"
     (error) ="onImgError($event)">
     <div class="card-body">
         <h5 class="card-title">Name: {{cat.name}}</h5>

--- a/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.css
+++ b/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.css
@@ -118,5 +118,9 @@ mark {
 }
 
 #button-footer{
-  background-color: #45b678;
+  background-color: #333;
+}
+
+.showDeleteErrorMessage{
+  color:#F89191
 }

--- a/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.css
+++ b/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.css
@@ -3,7 +3,7 @@ body{
     margin-top:20px;
 }
 .section {
-    padding: 100px 0;
+    padding: 25px 0;
     position: relative;
 }
 .gray-bg {
@@ -49,14 +49,13 @@ img {
   padding: 5px 0;
 }
 .about-list label {
-  color: #20247b;
+  color: #333;
   font-weight: 600;
   width: 200px;
   margin: 0;
   position: relative;
 }
 .about-list label:after {
-  content: "";
   position: absolute;
   top: 0;
   bottom: 0;
@@ -95,7 +94,7 @@ img {
 }
 .about-section .counter .count {
   font-weight: 700;
-  color: #20247b;
+  color: #1a7442;
   margin: 0 0 5px;
 }
 .about-section .counter p {
@@ -112,8 +111,12 @@ mark {
     color: currentColor;
 }
 .theme-color {
-    color: #fc5356;
+    color: #333;;
 }
 .dark-color {
-    color: #20247b;
+    color:  #1f5035;
+}
+
+#button-footer{
+  background-color: #45b678;
 }

--- a/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.html
@@ -105,7 +105,7 @@
 
                 <div class="col">
                     <div class="count-data text-center">
-                        <button type="button" class="btn btn-danger">Delete Profile</button>
+                        <button (click)="deleteCat()" type="button" class="btn btn-danger">Delete Profile</button>
                     </div>
                 </div>
             </div>

--- a/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.html
@@ -80,16 +80,18 @@
                     <img class="rounded" src="{{cat.fileDownloadUri}}" alt="{{cat.fileName}}" width="300" height="300"
     (error) ="onImgError($event)">
                 </div>
-                <div class="media">
+                <div class="media about-list">
                     <label>Date Captured:</label>
                     <p>{{cat.dateCaptured}}</p>
                 </div>
-                <h6 class="theme-color lead">Notes:</h6>
+                <div class="media about-list">
+                    <label>Notes:</label>
                     <p>{{cat.notes}}</p>
+                    </div>
             </div>
         </div>
         
-        <div class="counter">
+        <div class="counter" id="button-footer">
             <div class="row">
                 <div class="col">
                     <div class="count-data text-center">

--- a/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.html
@@ -74,6 +74,7 @@
                     </div>
                 </div>
             </div>
+
             <div class="col-lg-6">
                 <div class="about-avatar">
                     <img class="rounded" src="{{cat.fileDownloadUri}}" alt="{{cat.fileName}}" width="300" height="300"
@@ -96,18 +97,18 @@
                             <a routerLink="/updateCat" [queryParams]="{ microchipNumber: cat.microchipNumber }" class="btn btn-primary">
                                 Update Profile
                             </a>
-                      
                         </div>
                     </div>
                 </div>
+
                 <div class="col">
                     <div class="count-data text-center">
                         <button type="button" class="btn btn-danger">Delete Profile</button>
                     </div>
                 </div>
-                
-               
             </div>
         </div>
+
     </div>
+
 </section>

--- a/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.html
@@ -106,9 +106,9 @@
                 <div class="col">
                     <div *ngIf= "showDeleteButton" class="count-data text-center">
                         <button (click)="deleteCat()" type="button" class="btn btn-danger">{{deleteButtonText}}</button>
-                    </div>
-                    <p  *ngIf="showDeleteErrorMessage" class="showSubmitErrorMessage btn btn-danger">Unable to Delete. Please Try Again!</p>
-                   
+                    
+                    <p  *ngIf="showDeleteErrorMessage" class="showDeleteErrorMessage">Unable to Delete. Please Try Again!</p>
+                </div>
                 </div>
             </div>
         </div>

--- a/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.html
@@ -104,9 +104,11 @@
                 </div>
 
                 <div class="col">
-                    <div class="count-data text-center">
-                        <button (click)="deleteCat()" type="button" class="btn btn-danger">Delete Profile</button>
+                    <div *ngIf= "showDeleteButton" class="count-data text-center">
+                        <button (click)="deleteCat()" type="button" class="btn btn-danger">{{deleteButtonText}}</button>
                     </div>
+                    <p  *ngIf="showDeleteErrorMessage" class="showSubmitErrorMessage btn btn-danger">Unable to Delete. Please Try Again!</p>
+                   
                 </div>
             </div>
         </div>

--- a/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.ts
+++ b/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.ts
@@ -19,6 +19,7 @@ export class CatProfilePageComponent {
   showDeleteButton= true;
   showDeleteErrorMessage = false;
   deleted = false;
+  deleteButtonText = "Delete Cat";
 
    
 
@@ -49,15 +50,16 @@ export class CatProfilePageComponent {
         this.deleted= true;
         this.showDeleteErrorMessage = false;
         
-    
+        if(confirm("Are you sure you want to delete " +this.cat.name +"? This cannot be undone!")){
     
         this.deleteCatService.deleteCatByMicrochipNumber(this.microchipNumber).subscribe(
     
           (result) => {
             {          
               this.showDeleteSuccessMessage = true;
-              this.showDeleteButton = false;
+              this.showDeleteButton = true;
               this.showDeleteErrorMessage = false;
+              this.deleteButtonText = "Cat Deleted!"
           setTimeout(() => {
                  this.router.navigate(['/find'],
                 
@@ -70,10 +72,11 @@ export class CatProfilePageComponent {
             this.showDeleteSuccessMessage = false;
             this.showDeleteButton = true; 
             this.showDeleteErrorMessage= true
+            this.deleteButtonText = "Delete Cat"
             
           }
         );
         }
-    
+      }
       }
   

--- a/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.ts
+++ b/feral-cat-tracker-UI/src/app/cat-profile-page/cat-profile-page.component.ts
@@ -2,6 +2,8 @@ import { Component,Input } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Cat } from '../models/cat';
 import { FindcatserviceService } from '../findcatservice/findcatservice.service';
+import { DeleteCatServiceService } from '../delete-cat-service/delete-cat-service.service';
+import { Router } from '@angular/router';
 
 export type catSearchDisplay = Partial<Cat>
 
@@ -13,6 +15,10 @@ export type catSearchDisplay = Partial<Cat>
 export class CatProfilePageComponent {
   microchipNumber= ""
   cat!: Cat;
+  showDeleteSuccessMessage = false;
+  showDeleteButton= true;
+  showDeleteErrorMessage = false;
+  deleted = false;
 
    
 
@@ -21,9 +27,10 @@ export class CatProfilePageComponent {
 }
 
   
-    constructor(private route: ActivatedRoute, private findcatService: FindcatserviceService) {
-    
-       }
+    constructor(private route: ActivatedRoute, 
+      private findcatService: FindcatserviceService,
+       private deleteCatService: DeleteCatServiceService,
+       private router: Router) {}
   
        ngOnInit(): void {
         this.route.queryParams.subscribe((params: any) => {
@@ -35,4 +42,38 @@ export class CatProfilePageComponent {
           })
         }) 
       }
-  }
+
+      deleteCat() {
+        this.showDeleteSuccessMessage = false;
+        this.showDeleteButton = true;
+        this.deleted= true;
+        this.showDeleteErrorMessage = false;
+        
+    
+    
+        this.deleteCatService.deleteCatByMicrochipNumber(this.microchipNumber).subscribe(
+    
+          (result) => {
+            {          
+              this.showDeleteSuccessMessage = true;
+              this.showDeleteButton = false;
+              this.showDeleteErrorMessage = false;
+          setTimeout(() => {
+                 this.router.navigate(['/find'],
+                
+                  ); 
+          } , 5000);
+        }
+          
+          },
+          (error) => {
+            this.showDeleteSuccessMessage = false;
+            this.showDeleteButton = true; 
+            this.showDeleteErrorMessage= true
+            
+          }
+        );
+        }
+    
+      }
+  

--- a/feral-cat-tracker-UI/src/app/delete-cat-service/delete-cat-service.service.spec.ts
+++ b/feral-cat-tracker-UI/src/app/delete-cat-service/delete-cat-service.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DeleteCatServiceService } from './delete-cat-service.service';
+
+describe('DeleteCatServiceService', () => {
+  let service: DeleteCatServiceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DeleteCatServiceService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/feral-cat-tracker-UI/src/app/delete-cat-service/delete-cat-service.service.ts
+++ b/feral-cat-tracker-UI/src/app/delete-cat-service/delete-cat-service.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { Cat } from '../models/cat';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DeleteCatServiceService {
+
+  private deleteApiUrl = 'http://localhost:8080/delete';
+
+
+  constructor(private http: HttpClient) { }
+
+  deleteCatByMicrochipNumber(microchipNumber: string): Observable<any> {
+    console.log('')
+    return   this.http.post(this.deleteApiUrl, microchipNumber, {
+      reportProgress: true,
+      responseType: 'text',
+      withCredentials: true 
+    });
+  }
+}

--- a/feral-cat-tracker-UI/src/app/findcatservice/findcatservice.service.ts
+++ b/feral-cat-tracker-UI/src/app/findcatservice/findcatservice.service.ts
@@ -31,6 +31,4 @@ export class FindcatserviceService {
     console.log('')
     return this.http.get<Cat[]>(`${this.findByMicrochipURL}?microchipNumber=${microchipNumber}`, { withCredentials: true });
   }
-
-  //todo maybe findcaybyid
 }

--- a/feral-cat-tracker-UI/src/app/findcatservice/findcatservice.service.ts
+++ b/feral-cat-tracker-UI/src/app/findcatservice/findcatservice.service.ts
@@ -29,7 +29,7 @@ export class FindcatserviceService {
 
   findCatByMicrochipNumber(microchipNumber: string): Observable<any> {
     console.log('')
-    return this.http.get<Cat[]>(`${this.findByMicrochipURL}?microchipNumber=${microchipNumber}`);
+    return this.http.get<Cat[]>(`${this.findByMicrochipURL}?microchipNumber=${microchipNumber}`, { withCredentials: true });
   }
 
   //todo maybe findcaybyid

--- a/feral-cat-tracker-UI/src/app/logcat/logcat.component.html
+++ b/feral-cat-tracker-UI/src/app/logcat/logcat.component.html
@@ -159,7 +159,7 @@
             <button type="submit" class="btn btn-primary">Log Cat</button>
         </div>
         <p  *ngIf="showSubmitErrorMessage" class="showSubmitErrorMessage">Unable to save this cat. Please Try Again!</p>
-        <div *ngIf="showSuccessMessage" class="successMessage">Success! Thank you for tracking our commnity cats!</div>
+        <div *ngIf="showSuccessMessage" class="successMessage">Success! Thank you for tracking our community cats!</div>
 
     </form>
 </div>

--- a/feral-cat-tracker-UI/src/app/logcatservice/logcatservice.service.ts
+++ b/feral-cat-tracker-UI/src/app/logcatservice/logcatservice.service.ts
@@ -20,4 +20,18 @@ export class LogcatserviceService {
       withCredentials: true 
     });
   }
+  update(data: any, file: File): Observable<any>{
+    const formData: FormData = new FormData();
+      formData.append('cat', data);
+      formData.append('file', file);
+    
+    return this.http.post('http://localhost:8080/update', formData, {
+      reportProgress: true,
+      responseType: 'text',
+      withCredentials: true 
+    });
+  }
+
 }
+
+

--- a/feral-cat-tracker-UI/src/app/register/register.component.html
+++ b/feral-cat-tracker-UI/src/app/register/register.component.html
@@ -49,7 +49,7 @@
 
         <div class="form-group">
             <label for="phoneNumber" class="form-label">Phone Number</label>
-            <input type="phoneNumber" class="form-control" id="phoneNumber" aria-describedby="phoneNumberField"
+            <input type="phoneNumber" mask='(000) 000-0000' class="form-control" id="phoneNumber" aria-describedby="phoneNumberField"
                 formControlName="phoneNumber">
         </div>
         <div class="form-group">

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.css
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.css
@@ -130,3 +130,6 @@ input.ng-touched.ng-invalid {
   border: 1px solid red;
 }
 
+.showSubmitErrorMessage{
+  color:rgb(119, 15, 15)
+}

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.css
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.css
@@ -120,3 +120,13 @@ mark {
 #button-footer{
   background-color: #45b678;
 }
+
+
+.ng-invalid  {
+  border-left: 5px solid #a94442; /* red */
+}
+
+input.ng-touched.ng-invalid {
+  border: 1px solid red;
+}
+

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.css
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.css
@@ -118,7 +118,7 @@ mark {
 }
 
 #button-footer{
-  background-color: #45b678;
+  background-color: #333;
 }
 
 
@@ -131,5 +131,5 @@ input.ng-touched.ng-invalid {
 }
 
 .showSubmitErrorMessage{
-  color:rgb(119, 15, 15)
+  color:#F89191
 }

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.css
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.css
@@ -3,7 +3,7 @@ body{
     margin-top:20px;
 }
 .section {
-    padding: 100px 0;
+    padding: 25px 0;
     position: relative;
 }
 .gray-bg {
@@ -49,14 +49,13 @@ img {
   padding: 5px 0;
 }
 .about-list label {
-  color: #20247b;
+  color:  #333;
   font-weight: 600;
   width: 200px;
   margin: 0;
   position: relative;
 }
 .about-list label:after {
-  content: "";
   position: absolute;
   top: 0;
   bottom: 0;
@@ -95,7 +94,7 @@ img {
 }
 .about-section .counter .count {
   font-weight: 700;
-  color: #20247b;
+  color: #1a7442;
   margin: 0 0 5px;
 }
 .about-section .counter p {
@@ -112,8 +111,12 @@ mark {
     color: currentColor;
 }
 .theme-color {
-    color: #fc5356;
+    color: #333;
 }
 .dark-color {
-    color: #20247b;
+    color: #1f5035;
+}
+
+#button-footer{
+  background-color: #45b678;
 }

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.css
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.css
@@ -1,0 +1,119 @@
+body{
+    color: #6F8BA4;
+    margin-top:20px;
+}
+.section {
+    padding: 100px 0;
+    position: relative;
+}
+.gray-bg {
+    background-color: #f5f5f5;
+}
+img {
+    max-width: 100%;
+}
+img {
+    vertical-align: middle;
+    border-style: none;
+}
+/* About Me 
+---------------------*/
+.about-text h3 {
+  font-size: 45px;
+  font-weight: 700;
+  margin: 0 0 6px;
+}
+
+.about-text h6 {
+  font-weight: 600;
+  margin-bottom: 15px;
+}
+@media (max-width: 767px) {
+  .about-text h6 {
+    font-size: 18px;
+  }
+}
+.about-text p {
+  font-size: 18px;
+  max-width: 450px;
+}
+.about-text p mark {
+  font-weight: 600;
+  color: #20247b;
+}
+
+.about-list {
+  padding-top: 10px;
+}
+.about-list .media {
+  padding: 5px 0;
+}
+.about-list label {
+  color: #20247b;
+  font-weight: 600;
+  width: 200px;
+  margin: 0;
+  position: relative;
+}
+.about-list label:after {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 11px;
+  width: 1px;
+  height: 12px;
+  background: #20247b;
+  -moz-transform: rotate(15deg);
+  -o-transform: rotate(15deg);
+  -ms-transform: rotate(15deg);
+  -webkit-transform: rotate(15deg);
+  transform: rotate(15deg);
+  margin: auto;
+  opacity: 0.5;
+}
+.about-list p {
+  margin: 0;
+  font-size: 15px;
+}
+
+@media (max-width: 991px) {
+  .about-avatar {
+    margin-top: 30px;
+  }
+}
+
+.about-section .counter {
+  padding: 22px 20px;
+  background: #ffffff;
+  border-radius: 10px;
+  box-shadow: 0 0 30px rgba(31, 45, 61, 0.125);
+}
+.about-section .counter .count-data {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+.about-section .counter .count {
+  font-weight: 700;
+  color: #20247b;
+  margin: 0 0 5px;
+}
+.about-section .counter p {
+  font-weight: 600;
+  margin: 0;
+}
+mark {
+    background-image: linear-gradient(rgba(252, 83, 86, 0.6), rgba(252, 83, 86, 0.6));
+    background-size: 100% 3px;
+    background-repeat: no-repeat;
+    background-position: 0 bottom;
+    background-color: transparent;
+    padding: 0;
+    color: currentColor;
+}
+.theme-color {
+    color: #fc5356;
+}
+.dark-color {
+    color: #20247b;
+}

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
@@ -1,5 +1,6 @@
 <section class="section about-section gray-bg" id="about">
-    <div class="container" [formGroup]="catForm">
+    <div class="container" >
+        <form [formGroup]="catForm" (ngSubmit)="postUpdateCat()">
         <div class="row align-items-center flex-row-reverse">
             <div  class="col-lg-6">
                 <div class="about-text go-to">
@@ -8,7 +9,16 @@
                         <div class="col-md-6">
                             <div class="media">
                                 <label>Microchip Number:</label>
-                                <p>{{updateCat.microchipNumber}}</p>
+                                <input type="text" value={{updateCat.microchipNumber}} 
+                                [readonly]="true"
+                                class="form-control" id="microchipNumber"
+                                    aria-describedby="microchipNumber"
+                                    matTooltip="microchipNumber"
+                                    matTooltipPosition="left" formControlName="microchipNumber"
+                                    [ngClass]="{ 'is-invalid': submitted && f['microchipNumber'].errors }">
+                                <div *ngIf="submitted && f['microchipNumber'].errors" class="invalid-feedback">
+                                    <div *ngIf="f['microchipNumber'].errors['required']">microchipNumber is required.</div>
+                                </div>
                             </div>
 
                             <div class="media">
@@ -87,7 +97,7 @@
                                     matTooltip="Enter the estimated age of the cat in years." matTooltipPosition="left"
                                     formControlName="estimatedAge">
                             </div>
-</div>
+                        </div>
                             <div class="col-md-6">
                                 <div class="media">
                                     <label>Altered Status:</label>
@@ -158,7 +168,7 @@
                             (change)="selectFile($event)" />
                     </div>
                     <div class="media about-list">
-                        <label class=>Date Captured:</label>
+                        <label>Date Captured:</label>
                         <input type="date" class="form-control" value={{updateCat.dateCaptured}} id="dateCaptured"
                             aria-describedby="dateCaptured" matTooltip="Enter date captured." matTooltipPosition="left"
                             formControlName="dateCaptured">
@@ -171,16 +181,17 @@
                     </textarea>
                     </div>
                 </div>
-            </div>
-        </div>    
+            </div>        
 
             <div class="counter" id="button-footer">
                 <div class="row" >
                     <div class="col" >
                         <div class="count-data text-center" >
                             <div class="btn-container">
-                                <button type="button" class="btn btn-primary">Submit Changes</button>
+                                <button type="submit" class="btn btn-primary">Update Profile</button>
                             </div>
+                            <p  *ngIf="showSubmitErrorMessage" class="showSubmitErrorMessage">Unable to update cat. Please Try Again!</p>
+                            <div *ngIf="showSuccessMessage" class="successMessage">Update Successful!</div>
                         </div>
                     </div>
 
@@ -190,6 +201,9 @@
                         </div>
                     </div>
                 </div>
+                </div>
 
-</div>
-</section>
+            </form>
+            </div>
+
+        </section>

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
@@ -187,8 +187,8 @@
                 <div class="row" >
                     <div class="col" >
                         <div class="count-data text-center" >
-                            <div class="btn-container">
-                                <button type="submit" class="btn btn-primary">Update Profile</button>
+                            <div *ngIf="showSubmitButton" class="btn-container">
+                                <button type="submit" class="btn btn-primary">Submit Updates</button>
                             </div>
                             <p  *ngIf="showSubmitErrorMessage" class="showSubmitErrorMessage">Unable to update cat. Please Try Again!</p>
                             <div *ngIf="showSuccessMessage" class="successMessage">Update Successful!</div>

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
@@ -3,72 +3,72 @@
         <div class="row align-items-center flex-row-reverse">
             <div class="col-lg-6">
                 <div class="about-text go-to">
-                    <h3 class="dark-color">{{cat.name}}</h3>
+                    <h3 class="dark-color">{{updateCat.name}}</h3>
                     
                     <div class="row about-list">
                         <div class="col-md-6">
                             <div class="media">
                                 <label>Microchip Number:</label>
-                                <p>{{cat.microchipNumber}}</p>
+                                <p>{{updateCat.microchipNumber}}</p>
                             </div>
                             <div class="media">
                                 <label>Sex:</label>
-                                <p>{{cat.sex}}</p>
+                                <p>{{updateCat.sex}}</p>
                             </div>
                             <div class="media">
                                 <label>General Location:</label>
-                                <p>{{cat.addressLastSeen}}</p>
+                                <p>{{updateCat.addressLastSeen}}</p>
                             </div>
                             <div class="media">
                                 <label>Breed:</label>
-                                <p>{{cat.breed}}</p>
+                                <p>{{updateCat.breed}}</p>
                             </div>
                             <div class="media">
                                 <label>Dominant Color:</label>
-                                <p>{{cat.color}}</p>
+                                <p>{{updateCat.color}}</p>
                             </div>
                             <div class="media">
                                 <label>Fur Type:</label>
-                                <p>{{cat.furType}}</p>
+                                <p>{{updateCat.furType}}</p>
                             </div>
                             <div class="media">
                                 <label>Weight in Pounds:</label>
-                                <p>{{cat.weight}}</p>
+                                <p>{{updateCat.weight}}</p>
                             </div>
                             <div class="media">
                                 <label>Approx. Age:</label>
-                                <p>{{cat.estimatedAge}}</p>
+                                <p>{{updateCat.estimatedAge}}</p>
                             </div>
                         </div>
                         <div class="col-md-6">
                             <div class="media">
                                 <label>Altered Status:</label>
-                                <p>{{cat.alteredStatus}}</p>
+                                <p>{{updateCat.alteredStatus}}</p>
                             </div>
                            
                             <div class="media">
                                 <label>Rabies Vaccine Date:</label>
-                                <p>{{cat.rabiesVaccineDate}}</p>
+                                <p>{{updateCat.rabiesVaccineDate}}</p>
                             </div>
                             <div class="media">
                                 <label>Distemper Vaccine Date:</label>
-                                <p>{{cat.distemperVaccineDate}}</p>
+                                <p>{{updateCat.distemperVaccineDate}}</p>
                             </div>
                             <div class="media">
                                 <label>FHV Vaccine Date:</label>
-                                <p>{{cat.fhvVaccineDate}}</p>
+                                <p>{{updateCat.fhvVaccineDate}}</p>
                             </div>
                             <div class="media">
                                 <label>FIV Vaccine Date:</label>
-                                <p>{{cat.fivVaccineDate}}</p>
+                                <p>{{updateCat.fivVaccineDate}}</p>
                             </div>
                             <div class="media">
                                 <label>FelV Vaccine Date:</label>
-                                <p>{{cat.felvVaccineDate}}</p>
+                                <p>{{updateCat.felvVaccineDate}}</p>
                             </div>
                             <div class="media">
                                 <label>Bordetella Vaccine Date:</label>
-                                <p>{{cat.bordetellaVaccineDate}}</p>
+                                <p>{{updateCat.bordetellaVaccineDate}}</p>
                             </div>
                         </div>
                     </div>
@@ -76,15 +76,15 @@
             </div>
             <div class="col-lg-6">
                 <div class="about-avatar">
-                    <img class="rounded" src="{{cat.fileDownloadUri}}" alt="{{cat.fileName}}" width="300" height="300"
+                    <img class="rounded" src="{{updateCat.fileDownloadUri}}" alt="{{updateCat.fileName}}" width="300" height="300"
     (error) ="onImgError($event)">
                 </div>
                 <div class="media">
                     <label>Date Captured:</label>
-                    <p>{{cat.dateCaptured}}</p>
+                    <p>{{updateCat.dateCaptured}}</p>
                 </div>
                 <h6 class="theme-color lead">Notes:</h6>
-                    <p>{{cat.notes}}</p>
+                    <p>{{updateCat.notes}}</p>
             </div>
         </div>
         
@@ -93,10 +93,7 @@
                 <div class="col">
                     <div class="count-data text-center">
                         <div class="btn-container">
-                            <a routerLink="/updateCat" [queryParams]="{ microchipNumber: cat.microchipNumber }" class="btn btn-primary">
-                                Update Profile
-                            </a>
-                      
+                            <button type="button" class="btn btn-primary">Update Profile</button>  
                         </div>
                     </div>
                 </div>

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
@@ -188,10 +188,9 @@
                     <div class="col" >
                         <div class="count-data text-center" >
                             <div *ngIf="showSubmitButton" class="btn-container">
-                                <button type="submit" class="btn btn-primary">Submit Updates</button>
+                                <button type="submit" class="btn btn-primary">{{updateButtonText}}</button>
                             </div>
                             <p  *ngIf="showSubmitErrorMessage" class="showSubmitErrorMessage">Unable to update cat. Please Try Again!</p>
-                            <div *ngIf="showSuccessMessage" class="successMessage">Update Successful!</div>
                         </div>
                     </div>
 

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
@@ -197,7 +197,7 @@
 
                     <div class="col">
                         <div class="count-data text-center">
-                            <button type="button" class="btn btn-danger">Cancel Changes</button>
+                            <a routerLink="/catProfile" [queryParams]="{ microchipNumber: updateCat.microchipNumber }"><button type="button" class="btn btn-danger">Cancel Changes</button></a>
                         </div>
                     </div>
                 </div>

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
@@ -1,110 +1,193 @@
 <section class="section about-section gray-bg" id="about">
-    <div class="container">
+    <div class="container" [formGroup]="catForm">
         <div class="row align-items-center flex-row-reverse">
-            <div class="col-lg-6">
+            <div  class="col-lg-6">
                 <div class="about-text go-to">
                     <h3 class="dark-color">{{updateCat.name}}</h3>
-                    
                     <div class="row about-list">
                         <div class="col-md-6">
                             <div class="media">
                                 <label>Microchip Number:</label>
                                 <p>{{updateCat.microchipNumber}}</p>
                             </div>
+
                             <div class="media">
                                 <label>Sex:</label>
-                                <p>{{updateCat.sex}}</p>
+                                <select type="text" value={{updateCat.sex}} class="form-control" id="sex"
+                                    aria-describedby="sex" formControlName="sex"
+                                    [ngClass]="{ 'is-invalid': submitted && f['sex'].errors }">
+                                    <option [ngValue]="'Female'">Female</option>
+                                    <option [ngValue]="'Male'">Male</option>
+                                </select>
+                                <div *ngIf="submitted && f['sex'].errors" class="invalid-feedback">
+                                    <div *ngIf="f['sex'].errors['required']">Sex is required.</div>
+                                </div>
                             </div>
+
                             <div class="media">
                                 <label>General Location:</label>
-                                <p>{{updateCat.addressLastSeen}}</p>
+                                <input type="text" value={{updateCat.addressLastSeen}} class="form-control"
+                                    id="addressLastSeen" aria-describedby="addressLastSeen"
+                                    matTooltip="Enter the closest address the cat was last seen. Format: Street, City, State Zip (i.e. 100 main street, Kansas City, MO 64105)"
+                                    matTooltipPosition="left" formControlName="addressLastSeen"
+                                    [ngClass]="{ 'is-invalid': submitted && f['addressLastSeen'].errors }">
+                                <div *ngIf="submitted && f['addressLastSeen'].errors" class="invalid-feedback">
+                                    <div *ngIf="f['addressLastSeen'].errors['required']">Address last seen is required.
+                                    </div>
+                                </div>
                             </div>
                             <div class="media">
                                 <label>Breed:</label>
-                                <p>{{updateCat.breed}}</p>
+                                <input type="text" value={{updateCat.breed}} class="form-control" id="breed"
+                                    aria-describedby="breed"
+                                    matTooltip="Enter breed or mixes such as Siamese, shorthair, ragdoll, fold, etc."
+                                    matTooltipPosition="left" formControlName="breed"
+                                    [ngClass]="{ 'is-invalid': submitted && f['breed'].errors }">
+                                <div *ngIf="submitted && f['breed'].errors" class="invalid-feedback">
+                                    <div *ngIf="f['breed'].errors['required']">Breed is required.</div>
+                                </div>
                             </div>
                             <div class="media">
                                 <label>Dominant Color:</label>
-                                <p>{{updateCat.color}}</p>
+                                <input type="text" value={{updateCat.color}} class="form-control" id="color"
+                                    aria-describedby="color"
+                                    matTooltip="Enter color of fur such as tortie, grey, calico, etc."
+                                    matTooltipPosition="left" formControlName="color"
+                                    [ngClass]="{ 'is-invalid': submitted && f['color'].errors }">
+                                <div *ngIf="submitted && f['color'].errors" class="invalid-feedback">
+                                    <div *ngIf="f['color'].errors['required']">Color is required.</div>
+                                </div>
                             </div>
                             <div class="media">
                                 <label>Fur Type:</label>
-                                <p>{{updateCat.furType}}</p>
+                                <select type="furType" value={{updateCat.furType}} class="form-control" id="furType"
+                                    aria-describedby="furType"
+                                    matTooltip="Describe the length and type of fur the cat has."
+                                    matTooltipPosition="left" formControlName="furType"
+                                    [ngClass]="{ 'is-invalid': submitted && f['furType'].errors }">
+                                    <option [ngValue]="'Long Hair'">Long Hair</option>
+                                    <option [ngValue]="'Short Hair'">Short Hair</option>
+                                    <option [ngValue]="'Bald'">Bald</option>
+                                </select>
+                                <div *ngIf="submitted && f['furType'].errors" class="invalid-feedback">
+                                    <div *ngIf="f['furType'].errors['required']">Fur Type is required.</div>
+                                </div>
                             </div>
+
                             <div class="media">
                                 <label>Weight in Pounds:</label>
-                                <p>{{updateCat.weight}}</p>
+                                <input type="number" min="0" value={{updateCat.weight}} class="form-control" id="weight"
+                                    aria-describedby="weight" matTooltip="Estimated or current weight of the cat"
+                                    matTooltipPosition="left" formControlName="weight">
                             </div>
                             <div class="media">
                                 <label>Approx. Age:</label>
-                                <p>{{updateCat.estimatedAge}}</p>
+                                <input type="number" min="0" value={{updateCat.estimatedAge}} class="form-control"
+                                    id="weight" aria-describedby="estimatedAge"
+                                    matTooltip="Enter the estimated age of the cat in years." matTooltipPosition="left"
+                                    formControlName="estimatedAge">
                             </div>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="media">
-                                <label>Altered Status:</label>
-                                <p>{{updateCat.alteredStatus}}</p>
+</div>
+                            <div class="col-md-6">
+                                <div class="media">
+                                    <label>Altered Status:</label>
+                                    <select type="alteredStatus" value={{updateCat.alteredStatus}} class="form-control"
+                                        id="alteredStatus" aria-describedby="estimatedAge"
+                                        matTooltip="Select if the cat is spayed or intact." matTooltipPosition="left"
+                                        formControlName="alteredStatus">
+                                        <option [ngValue]="'Intact'">Intact</option>
+                                        <option [ngValue]="'Spayed / Neutered'">Spayed / Neutered</option>
+                                    </select>
+                                </div>
+
+                                <div class="media">
+                                    <label>Rabies Vaccine Date:</label>
+                                    <input type="date" class="form-control" value={{updateCat.rabiesVaccineDate}}
+                                        id="rabiesVaccineDate" aria-describedby="rabiesVaccineDate"
+                                        matTooltip="Enter most recent Rabies vaccine date." matTooltipPosition="left"
+                                        formControlName="rabiesVaccineDate">
+                                </div>
+                                <div class="media">
+                                    <label>Distemper Vaccine Date:</label>
+                                    <input type="date" class="form-control" value={{updateCat.distemperVaccineDate}}
+                                        id="distemperVaccineDate" aria-describedby="distemperVaccineDate"
+                                        matTooltip="Enter most recent Distemper vaccine date." matTooltipPosition="left"
+                                        formControlName="distemperVaccineDate">
+                                </div>
+                                <div class="media">
+                                    <label>FHV Vaccine Date:</label>
+                                    <input type="date" class="form-control" value={{updateCat.fhvVaccineDate}}
+                                        id="fhvVaccineDate" aria-describedby="fhvVaccineDate"
+                                        matTooltip="Enter most recent FHV vaccine date." matTooltipPosition="left"
+                                        formControlName="fhvVaccineDate">
+                                </div>
+                                <div class="media">
+                                    <label>FIV Vaccine Date:</label>
+                                    <input type="date" class="form-control" value={{updateCat.fivVaccineDate}}
+                                        id="fivVaccineDate" aria-describedby="fivVaccineDate"
+                                        matTooltip="Enter most recent FIV vaccine date." matTooltipPosition="left"
+                                        formControlName="fivVaccineDate">
+                                </div>
+                                <div class="media">
+                                    <label>FelV Vaccine Date:</label>
+                                    <input type="date" class="form-control" value={{updateCat.felvVaccineDate}}
+                                        id="felvVaccineDate" aria-describedby="felvVaccineDate"
+                                        matTooltip="Enter most recent FELV vaccine date." matTooltipPosition="left"
+                                        formControlName="felvVaccineDate">
+                                </div>
+                                <div class="media">
+                                    <label>Bordetella Vaccine Date:</label>
+                                    <input type="date" class="form-control" value={{updateCat.bordetellaVaccineDate}}
+                                        id="felvVaccineDate" aria-describedby="felvVaccineDate"
+                                        matTooltip="Enter most recent FELV vaccine date." matTooltipPosition="left"
+                                        formControlName="felvVaccineDate">
                             </div>
-                           
-                            <div class="media">
-                                <label>Rabies Vaccine Date:</label>
-                                <p>{{updateCat.rabiesVaccineDate}}</p>
-                            </div>
-                            <div class="media">
-                                <label>Distemper Vaccine Date:</label>
-                                <p>{{updateCat.distemperVaccineDate}}</p>
-                            </div>
-                            <div class="media">
-                                <label>FHV Vaccine Date:</label>
-                                <p>{{updateCat.fhvVaccineDate}}</p>
-                            </div>
-                            <div class="media">
-                                <label>FIV Vaccine Date:</label>
-                                <p>{{updateCat.fivVaccineDate}}</p>
-                            </div>
-                            <div class="media">
-                                <label>FelV Vaccine Date:</label>
-                                <p>{{updateCat.felvVaccineDate}}</p>
-                            </div>
-                            <div class="media">
-                                <label>Bordetella Vaccine Date:</label>
-                                <p>{{updateCat.bordetellaVaccineDate}}</p>
                             </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class="col-lg-6">
-                <div class="about-avatar">
-                    <img class="rounded" src="{{updateCat.fileDownloadUri}}" alt="{{updateCat.fileName}}" width="300" height="300"
-    (error) ="onImgError($event)">
+                <div class="col-lg-6">
+                    <div class="about-avatar">
+                        <img class="rounded" src="{{updateCat.fileDownloadUri}}" alt="{{updateCat.fileName}}"
+                            width="300" height="300" (error)="onImgError($event)">
+                    </div>
+                    <div class="form-group">
+                        <label for="image" class="form-label">Image</label>
+                        <input type="file" name="image" class="form-control" id="image" aria-describedby="image"
+                            formControlName="image" rows="4" cols="50" accept="image/png, image/jpeg"
+                            (change)="selectFile($event)" />
+                    </div>
+                    <div class="media">
+                        <label>Date Captured:</label>
+                        <input type="date" class="form-control" value={{updateCat.dateCaptured}} id="dateCaptured"
+                            aria-describedby="dateCaptured" matTooltip="Enter date captured." matTooltipPosition="left"
+                            formControlName="dateCaptured">
+                    </div>
+                    <h6 class="theme-color lead">Notes:</h6>
+                    <textarea type="text" class="form-control" id="notes" aria-describedby="notes"
+                        formControlName="notes" rows="4" cols="50">
+                        {{updateCat.notes}}
+                    </textarea>
                 </div>
-                <div class="media">
-                    <label>Date Captured:</label>
-                    <p>{{updateCat.dateCaptured}}</p>
-                </div>
-                <h6 class="theme-color lead">Notes:</h6>
-                    <p>{{updateCat.notes}}</p>
             </div>
-        </div>
-        
-        <div class="counter">
-            <div class="row">
-                <div class="col">
-                    <div class="count-data text-center">
-                        <div class="btn-container">
-                            <button type="button" class="btn btn-primary">Update Profile</button>  
+        </div>    
+
+            <div class="counter">
+                <div class="row">
+                    <div class="col">
+                        <div class="count-data text-center">
+                            <div class="btn-container">
+                                <button type="button" class="btn btn-primary">Submit Changes</button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col">
+                        <div class="count-data text-center">
+                            <button type="button" class="btn btn-danger">Cancel Changes</button>
                         </div>
                     </div>
                 </div>
-                <div class="col">
-                    <div class="count-data text-center">
-                        <button type="button" class="btn btn-danger">Delete Profile</button>
-                    </div>
-                </div>
-                
-               
-            </div>
-        </div>
-    </div>
+
+</div>
 </section>

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.html
@@ -151,31 +151,33 @@
                         <img class="rounded" src="{{updateCat.fileDownloadUri}}" alt="{{updateCat.fileName}}"
                             width="300" height="300" (error)="onImgError($event)">
                     </div>
-                    <div class="form-group">
-                        <label for="image" class="form-label">Image</label>
+                    <div class="form-group media about-list">
+                        <label for="image" class="form-label">Image:</label>
                         <input type="file" name="image" class="form-control" id="image" aria-describedby="image"
                             formControlName="image" rows="4" cols="50" accept="image/png, image/jpeg"
                             (change)="selectFile($event)" />
                     </div>
-                    <div class="media">
-                        <label>Date Captured:</label>
+                    <div class="media about-list">
+                        <label class=>Date Captured:</label>
                         <input type="date" class="form-control" value={{updateCat.dateCaptured}} id="dateCaptured"
                             aria-describedby="dateCaptured" matTooltip="Enter date captured." matTooltipPosition="left"
                             formControlName="dateCaptured">
                     </div>
-                    <h6 class="theme-color lead">Notes:</h6>
+                    <div class="media about-list">
+                    <label>Notes:</label>
                     <textarea type="text" class="form-control" id="notes" aria-describedby="notes"
                         formControlName="notes" rows="4" cols="50">
                         {{updateCat.notes}}
                     </textarea>
+                    </div>
                 </div>
             </div>
         </div>    
 
-            <div class="counter">
-                <div class="row">
-                    <div class="col">
-                        <div class="count-data text-center">
+            <div class="counter" id="button-footer">
+                <div class="row" >
+                    <div class="col" >
+                        <div class="count-data text-center" >
                             <div class="btn-container">
                                 <button type="button" class="btn btn-primary">Submit Changes</button>
                             </div>

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.spec.ts
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { UpdateCatProfilePageComponent } from './update-cat-profile-page.component';
+
+describe('UpdateCatProfilePageComponent', () => {
+  let component: UpdateCatProfilePageComponent;
+  let fixture: ComponentFixture<UpdateCatProfilePageComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [UpdateCatProfilePageComponent]
+    });
+    fixture = TestBed.createComponent(UpdateCatProfilePageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
@@ -120,7 +120,9 @@ export class UpdateCatProfilePageComponent implements OnInit {
               this.showSubmitButton = false;
               this.showSubmitErrorMessage = false;
           setTimeout(() => {
-                 this.router.navigate(['/find']); //TODO: navigate to page for created cat.
+                 this.router.navigate(['/catProfile'],
+                  {queryParams:{ microchipNumber: this.updateCat.microchipNumber }}
+                  ); //TODO: navigate to page for created cat.
           } , 5000);
         }
           

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
@@ -1,0 +1,93 @@
+import { Component,Input } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Cat } from '../models/cat';
+import { FindcatserviceService } from '../findcatservice/findcatservice.service';
+import { FormGroup} from '@angular/forms';
+import { Router } from '@angular/router';
+import { LogcatserviceService } from '../logcatservice/logcatservice.service';
+
+export type catSearchDisplay = Partial<Cat>
+
+@Component({
+  selector: 'app-update-cat-profile-page',
+  templateUrl: './update-cat-profile-page.component.html',
+  styleUrls: ['./update-cat-profile-page.component.css']
+})
+export class UpdateCatProfilePageComponent {
+  microchipNumber= ""
+  updateCat!: Cat;
+  showSuccessMessage = false;
+  showSubmitButton= true;
+  showSubmitErrorMessage = false;
+  submitted = false;
+  currentFile: File;
+  selectedFiles: FileList;
+  catForm!: FormGroup;
+  formvalue : string;
+
+   
+
+  onImgError(event) { 
+    event.target.src = '/assets/FeralCatTrackLogo.png';
+}
+
+  
+    constructor(private route: ActivatedRoute, private findcatService: FindcatserviceService, private router: Router, private catservice:LogcatserviceService) {
+    
+       }
+  
+       ngOnInit(): void {
+        this.route.queryParams.subscribe((params: any) => {
+          console.log(params)
+          this.microchipNumber = params["microchipNumber"]
+          this.findcatService.findCatByMicrochipNumber(this.microchipNumber).subscribe((data) => {
+            this.updateCat = data;
+            console.log(this.updateCat + "**response.cats**")
+          })
+        }) 
+      }
+
+      postUpdateCat() {
+        this.showSuccessMessage = false;
+        this.showSubmitButton = true;
+        this.submitted= true;
+        this.showSubmitErrorMessage = false;
+        this.submitted= true;
+    
+    if(this.selectedFiles != null){
+      this.currentFile = this.selectedFiles.item(0);
+    } else {
+      this.currentFile = null
+    }
+        console.log(this.currentFile);
+    
+        if(this.catForm.invalid) {
+          return;
+        }
+      
+        if(this.catForm.valid){
+          this.formvalue = JSON.stringify(this.catForm.value);
+        this.catservice.update(this.formvalue, this.currentFile).subscribe(
+    
+          (result) => {
+            {          
+              this.showSuccessMessage = true;
+              this.showSubmitButton = false;
+              this.showSubmitErrorMessage = false;
+          setTimeout(() => {
+                 this.router.navigate(['/find']); //TODO: navigate to page for created cat.
+          } , 5000);
+        }
+          
+          },
+          (error) => {
+            this.showSuccessMessage = false;
+            this.showSubmitButton = true; 
+            this.showSubmitErrorMessage= true
+            
+          }
+        );
+        }
+    
+      }
+  }

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
@@ -95,7 +95,7 @@ export class UpdateCatProfilePageComponent implements OnInit {
         this.showSubmitButton = true;
         this.submitted= true;
         this.showSubmitErrorMessage = false;
-        this.submitted= true;
+        
     
     if(this.selectedFiles != null){
       this.currentFile = this.selectedFiles.item(0);

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
@@ -2,7 +2,10 @@ import { Component,Input } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Cat } from '../models/cat';
 import { FindcatserviceService } from '../findcatservice/findcatservice.service';
-import { FormGroup} from '@angular/forms';
+import {  AbstractControl,
+  FormGroup,
+  FormControl,
+  Validators,} from '@angular/forms';
 import { Router } from '@angular/router';
 import { LogcatserviceService } from '../logcatservice/logcatservice.service';
 
@@ -25,6 +28,43 @@ export class UpdateCatProfilePageComponent {
   catForm!: FormGroup;
   formvalue : string;
 
+  initForm() {
+    this.catForm = new FormGroup(
+      {
+        microchipNumber: new FormControl('', [Validators.required]),
+        name: new FormControl(this.updateCat.name, [Validators.required]),
+        addressLastSeen: new FormControl(this.updateCat.addressLastSeen, [Validators.required]),
+        sex: new FormControl(this.updateCat.sex, [Validators.required]),
+        breed: new FormControl(this.updateCat.breed, [Validators.required]),
+        color: new FormControl(this.updateCat.color, [Validators.required]),
+        furType: new FormControl(this.updateCat.furType, [Validators.required]),
+        weight: new FormControl(this.updateCat.weight),
+        estimatedAge: new FormControl(this.updateCat.estimatedAge),
+        alteredStatus: new FormControl(this.updateCat.alteredStatus),
+        rabiesVaccineDate: new FormControl(this.updateCat.rabiesVaccineDate),
+        distemperVaccineDate: new FormControl(this.updateCat.distemperVaccineDate),
+        fhvVaccineDate: new FormControl(this.updateCat.fhvVaccineDate),
+        fivVaccineDate: new FormControl(this.updateCat.fivVaccineDate),
+        felvVaccineDate: new FormControl(this.updateCat.felvVaccineDate),
+        bordetellaVaccineDate: new FormControl(this.updateCat.bordetellaVaccineDate),
+        dateCaptured: new FormControl(this.updateCat.dateCaptured),
+        notes: new FormControl(this.updateCat.notes),
+        image: new FormControl(this.updateCat.image),
+        fileName: new FormControl(this.updateCat.fileName),
+        type: new FormControl(),
+        data: new FormControl(this.updateCat.data),
+        lastModifiedUser: new FormControl()
+      }
+    );
+  }
+
+  get f(): { [key: string]: AbstractControl } {
+    return this.catForm.controls;
+  }
+  selectFile(event) {
+    this.selectedFiles = event.target.files;
+  }
+
    
 
   onImgError(event) { 
@@ -42,9 +82,12 @@ export class UpdateCatProfilePageComponent {
           this.microchipNumber = params["microchipNumber"]
           this.findcatService.findCatByMicrochipNumber(this.microchipNumber).subscribe((data) => {
             this.updateCat = data;
-            console.log(this.updateCat + "**response.cats**")
+            console.log(JSON.stringify(this.updateCat) + "**response.cats**")
+            this.initForm();
+
           })
-        }) 
+        })
+ 
       }
 
       postUpdateCat() {

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
@@ -27,6 +27,7 @@ export class UpdateCatProfilePageComponent implements OnInit {
   selectedFiles: FileList;
   catForm!: FormGroup;
   formvalue : string;
+  updateButtonText = "Submit Updates"
 
   initForm() {
     this.catForm = new FormGroup(
@@ -117,8 +118,9 @@ export class UpdateCatProfilePageComponent implements OnInit {
           (result) => {
             {          
               this.showSuccessMessage = true;
-              this.showSubmitButton = false;
+              this.showSubmitButton = true;
               this.showSubmitErrorMessage = false;
+              this.updateButtonText= "Cat Updated Successfully!"
           setTimeout(() => {
                  this.router.navigate(['/catProfile'],
                   {queryParams:{ microchipNumber: this.updateCat.microchipNumber }}
@@ -131,6 +133,7 @@ export class UpdateCatProfilePageComponent implements OnInit {
             this.showSuccessMessage = false;
             this.showSubmitButton = true; 
             this.showSubmitErrorMessage= true
+            this.updateButtonText = "Submit Updates"
             
           }
         );

--- a/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
+++ b/feral-cat-tracker-UI/src/app/update-cat-profile-page/update-cat-profile-page.component.ts
@@ -1,4 +1,4 @@
-import { Component,Input } from '@angular/core';
+import { Component,Input, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Cat } from '../models/cat';
 import { FindcatserviceService } from '../findcatservice/findcatservice.service';
@@ -16,7 +16,7 @@ export type catSearchDisplay = Partial<Cat>
   templateUrl: './update-cat-profile-page.component.html',
   styleUrls: ['./update-cat-profile-page.component.css']
 })
-export class UpdateCatProfilePageComponent {
+export class UpdateCatProfilePageComponent implements OnInit {
   microchipNumber= ""
   updateCat!: Cat;
   showSuccessMessage = false;
@@ -31,7 +31,7 @@ export class UpdateCatProfilePageComponent {
   initForm() {
     this.catForm = new FormGroup(
       {
-        microchipNumber: new FormControl('', [Validators.required]),
+        microchipNumber: new FormControl(this.updateCat.microchipNumber, [Validators.required]),
         name: new FormControl(this.updateCat.name, [Validators.required]),
         addressLastSeen: new FormControl(this.updateCat.addressLastSeen, [Validators.required]),
         sex: new FormControl(this.updateCat.sex, [Validators.required]),
@@ -49,7 +49,7 @@ export class UpdateCatProfilePageComponent {
         bordetellaVaccineDate: new FormControl(this.updateCat.bordetellaVaccineDate),
         dateCaptured: new FormControl(this.updateCat.dateCaptured),
         notes: new FormControl(this.updateCat.notes),
-        image: new FormControl(this.updateCat.image),
+        image: new FormControl(),
         fileName: new FormControl(this.updateCat.fileName),
         type: new FormControl(),
         data: new FormControl(this.updateCat.data),
@@ -105,8 +105,10 @@ export class UpdateCatProfilePageComponent {
         console.log(this.currentFile);
     
         if(this.catForm.invalid) {
+          console.log("invalid")
           return;
         }
+            
       
         if(this.catForm.valid){
           this.formvalue = JSON.stringify(this.catForm.value);

--- a/feral-cat-tracker/src/main/java/com/spookycats/feralcattracker/controllers/CatDataController.java
+++ b/feral-cat-tracker/src/main/java/com/spookycats/feralcattracker/controllers/CatDataController.java
@@ -92,6 +92,32 @@ public class CatDataController {
         }
     }
 
+    @PostMapping( "/update")
+    public ResponseEntity<ResponseMessage> updateCat(@RequestParam("cat") String cat, @RequestPart(value = "file", required = false) MultipartFile file, HttpServletRequest request) throws IOException {
+        ResponseEntity response;
+        ObjectMapper mapper = new ObjectMapper();
+        CatDataFormDTO catDTO = mapper.readValue(cat, CatDataFormDTO.class);
+
+        if(catDTO.getMicrochipNumber() == null || catDTO.getMicrochipNumber().isBlank())
+        {
+            response = ResponseEntity.status(HttpStatus.BAD_REQUEST).body("All cats require a Microchip number.");
+            return response;
+        }
+        Boolean existingCat = catDataService.findExistingCat(catDTO);
+
+        try{
+            if(existingCat == true){
+                catDataService.updateCat(catDTO);
+                response = ResponseEntity.status(HttpStatus.OK).body("Existing Cat has been updated.");
+                return response;
+            }
+
+        } catch (Exception e) {
+            return response = ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).body("Unable to save the cat, please try again.");
+        }
+        return response = ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).body("Unable to save the cat, please try again.");
+    }
+
     @GetMapping("/cat_data/{id}")
     public ResponseEntity<byte[]> getFile(@PathVariable int id) {
         CatData cat = catDataService.getFile(id);

--- a/feral-cat-tracker/src/main/java/com/spookycats/feralcattracker/controllers/CatDataController.java
+++ b/feral-cat-tracker/src/main/java/com/spookycats/feralcattracker/controllers/CatDataController.java
@@ -41,6 +41,19 @@ public class CatDataController {
         return catDataService.findByMicrochip(microchipNumber);
     }
 
+    @PostMapping("/delete")
+    public ResponseEntity<ResponseMessage> deleteCatByMicrochipNumber(@RequestBody String microchipNumber){
+       ResponseEntity response;
+        try {
+           catDataService.deleteCatByMicrochip(microchipNumber);
+       } catch (Exception exception) {
+            response = ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Failed to delete cat");
+            return response;
+        }
+        response = ResponseEntity.status(HttpStatus.OK).body("Cat deleted.");
+        return response;
+    }
+
 
     @GetMapping("/results")
     public ResponseEntity<List<CatData>> findByQuery(@RequestParam("query") String query,

--- a/feral-cat-tracker/src/main/java/com/spookycats/feralcattracker/services/CatDataService.java
+++ b/feral-cat-tracker/src/main/java/com/spookycats/feralcattracker/services/CatDataService.java
@@ -97,5 +97,11 @@ public class CatDataService {
        return catRepository.findByMicrochipNumber(microchipNumber);
     }
 
+    public void deleteCatByMicrochip(String microchipNumber){
+        catRepository.delete(catRepository.findByMicrochipNumber(microchipNumber)
+        );
+
+    }
+
     // Create methods to call each repository method
 }

--- a/feral-cat-tracker/src/main/java/com/spookycats/feralcattracker/services/CatDataService.java
+++ b/feral-cat-tracker/src/main/java/com/spookycats/feralcattracker/services/CatDataService.java
@@ -1,4 +1,5 @@
 package com.spookycats.feralcattracker.services;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spookycats.feralcattracker.data.CatRepository;
 import com.spookycats.feralcattracker.models.CatData;
 import com.spookycats.feralcattracker.models.dto.CatDataFormDTO;
@@ -58,6 +59,23 @@ public class CatDataService {
     public void updateCat(CatDataFormDTO catDataFormDTO){
         CatData updateCat = catRepository.findByMicrochipNumber(catDataFormDTO.getMicrochipNumber());
         updateCat.setLastModifiedDate(String.valueOf(LocalDate.now()));
+        updateCat.setAddressLastSeen(catDataFormDTO.getAddressLastSeen());
+        updateCat.setSex(catDataFormDTO.getSex());
+        updateCat.setBreed(catDataFormDTO.getBreed());
+        updateCat.setColor(catDataFormDTO.getColor());
+        updateCat.setFurType(catDataFormDTO.getFurType());
+        updateCat.setWeight(catDataFormDTO.getWeight());
+        updateCat.setEstimatedAge(catDataFormDTO.getEstimatedAge());
+        updateCat.setAlteredStatus(catDataFormDTO.getAlteredStatus());
+        updateCat.setRabiesVaccineDate(catDataFormDTO.getRabiesVaccineDate());
+        updateCat.setDistemperVaccineDate(catDataFormDTO.getDistemperVaccineDate());
+        updateCat.setFhvVaccineDate(catDataFormDTO.getFhvVaccineDate());
+        updateCat.setFivVaccineDate(catDataFormDTO.getFivVaccineDate());
+        updateCat.setFelvVaccineDate(catDataFormDTO.getFelvVaccineDate());
+        updateCat.setBordetellaVaccineDate(catDataFormDTO.getBordetellaVaccineDate());
+        updateCat.setDateCaptured(catDataFormDTO.getDateCaptured());
+        updateCat.setNotes(catDataFormDTO.getNotes());
+        updateCat.setImage(catDataFormDTO.getImage());
         catRepository.save(updateCat);
         //TODO: Fix this class to update changed fields, ignore nulls. Right now it does not accept new field changes, just updates last modified date.
 


### PR DESCRIPTION
Cat profile Page has two buttons: Update Profile, Delete Cat

If you click on the update profile button, you will be taken to an update cat profile page with a similar layout to the original profile page, with modifiable text boxes that populate with the pre-existing cat data. Microchip also appears in a text box but it is NOT modifiable. If you hit the cancel button, you will be redirected to the cat's profile page with no changes saved. If you click Submit Updates, the button will change to indicate to the user that the submission is successful, and then take you back to the cat's profile page where you can see the profile with the new changes added. If the submission is not successful, an error message appears below the submit button, and you are still able to click submit if you want to try again.

Back to the cat profile page: If you hit the Delete Cat button, a confirmation message will appear for the user, to verify that they truly want to permanently delete a cat's profile. If the use selects OK on this message, the Delete Cat button will change to notify user of successful deletion, and then redirect to the Find a Cat page. The deleted profile is removed from the repository and also is deleted from the find a cat page. If the user selects Cancel on the confirmation message, nothing will happen and they will remain on the cat profile page. If the user selects to delete the cat, but for some reason it is not successful, an error message will appear below the Delete Cat button.

Some more CSS changes (Changed Button footer color of cat profile pages to match nav bar instead of green), found a typo on Log a cat that I corrected. 